### PR TITLE
chore: breaking change in DeviceAccess

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,28 +11,29 @@ include(cmake/set_default_flags.cmake)
 include(cmake/set_default_build_to_release.cmake)
 include(cmake/enable_code_style_check.cmake)
 
-find_package(ChimeraTK-DeviceAccess 03.00 REQUIRED)
+find_package(ChimeraTK-DeviceAccess 03.14 REQUIRED)
 
 include(FindPkgConfig)
 
 if(DEFINED EPICS_DIR)
   set(ENV{PKG_CONFIG_PATH} $ENV{PKG_CONFIG_PATH}:${EPICS_DIR}/base/lib/pkgconfig)
 endif()
+
 message("Using PKG_CONFIG_PATH=$ENV{PKG_CONFIG_PATH}")
 pkg_check_modules(EPICS REQUIRED epics-base-linux-x86_64)
 pkg_get_variable(EPICS_LIBS epics-base-linux-x86_64 EPICS_BASE_IOC_LIBS)
 
-list( APPEND CMAKE_INSTALL_RPATH ${EPICS_LIBRARY_DIRS} )
-include_directories( include ${EPICS_INCLUDE_DIRS})
+list(APPEND CMAKE_INSTALL_RPATH ${EPICS_LIBRARY_DIRS})
+include_directories(include ${EPICS_INCLUDE_DIRS})
 
 aux_source_directory(${CMAKE_SOURCE_DIR}/src library_sources)
 
-add_library(${PROJECT_NAME} SHARED ${library_sources} )
+add_library(${PROJECT_NAME} SHARED ${library_sources})
 set_target_properties(${PROJECT_NAME} PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_FULL_LIBRARY_VERSION} SOVERSION ${${PROJECT_NAME}_SOVERSION})
 target_link_libraries(${PROJECT_NAME} PUBLIC ChimeraTK::ChimeraTK-DeviceAccess
-                                      PRIVATE ${EPICS_LIBS} 
-                                      PRIVATE ${EPICS_LDFLAGS})
+  PRIVATE ${EPICS_LIBS}
+  PRIVATE ${EPICS_LDFLAGS})
 
 # binary used during the developement of the backend - they require the EPICS example IOC to be running
 add_executable(testRead test/read.C)
@@ -55,7 +56,7 @@ install(TARGETS ${PROJECT_NAME}
 
 # we support our cmake EXPORTS as imported targets
 set(PROVIDES_EXPORTED_TARGETS 1)
+
 # we need the public dependencies so create_cmake_config_files can find them as implicit dependencies
 list(APPEND ${PROJECT_NAME}_PUBLIC_DEPENDENCIES "ChimeraTK-DeviceAccess")
-include(${CMAKE_SOURCE_DIR}/cmake/create_cmake_config_files.cmake)  
-
+include(${CMAKE_SOURCE_DIR}/cmake/create_cmake_config_files.cmake)

--- a/include/EPICS-Backend.h
+++ b/include/EPICS-Backend.h
@@ -25,7 +25,6 @@ namespace ChimeraTK {
     ~EpicsBackend();
     static boost::shared_ptr<DeviceBackend> createInstance(
         std::string address, std::map<std::string, std::string> parameters);
-    void setBackendState(bool isFunctional) { _isFunctional = isFunctional; }
     bool _asyncReadActivated{false};
 
    protected:
@@ -36,7 +35,7 @@ namespace ChimeraTK {
      */
     RegisterCatalogue getRegisterCatalogue() const override { return RegisterCatalogue(_catalogue_mutable.clone()); };
 
-    void setException() override;
+    void setExceptionImpl() noexcept override;
 
     void open() override;
 
@@ -47,8 +46,6 @@ namespace ChimeraTK {
       ss << "EPICS Server";
       return ss.str();
     }
-
-    bool isFunctional() const override { return _isFunctional; };
 
     void activateAsyncRead() noexcept override;
 
@@ -80,8 +77,6 @@ namespace ChimeraTK {
      * Keep track if catalog is filled using this bool.
      */
     bool _catalogue_filled;
-
-    bool _isFunctional{false};
 
     double _caTimeout{1.0};
 

--- a/src/EPICSChannelManager.cc
+++ b/src/EPICSChannelManager.cc
@@ -41,11 +41,12 @@ namespace ChimeraTK {
     if(args.op == CA_OP_CONN_UP) {
       std::cout << "Channel access established." << std::endl;
       ChannelManager::getInstance().channelMap.at(args.chid)._connected = true;
-      backend->setBackendState(true);
+      // Note: backend opened/isFunctional state must not be set to open/function outside the open() function!
     }
     else if(args.op == CA_OP_CONN_DOWN) {
       std::cout << "Channel access closed." << std::endl;
-      backend->setBackendState(false);
+      backend->setException(std::string("Channel for PV ") +
+          ChannelManager::getInstance().channelMap.at(args.chid)._caName + " was disconnected.");
       std::lock_guard<std::mutex> lock(ChannelManager::getInstance().mapLock);
       // check if channel is in map -> map might be already cleared.
       if(ChannelManager::getInstance().channelMap.count(args.chid)) {


### PR DESCRIPTION
This PR makes the EpicsBackend compile again with the new/upcoming DeviceAccess version (see PR https://github.com/ChimeraTK/DeviceAccess/pull/378). I have not tested the changes, since there are no automated tests and I have no means to test it otherwise. It looks to be in any case that this backend is not really complying to the specifications.