### PR TITLE
Use the new ChimeraTK EPICS interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,11 @@
-project(ChimeraTK-DeviceAccess-EPICS-Backend)
-
 cmake_minimum_required(VERSION 3.16)
+
+project(ChimeraTK-DeviceAccess-EPICS-Backend)
 
 set(${PROJECT_NAME}_MAJOR_VERSION 00)
 set(${PROJECT_NAME}_MINOR_VERSION 02)
 set(${PROJECT_NAME}_PATCH_VERSION 01)
 include(cmake/set_version_numbers.cmake)
-
-option(BUILD_TESTS "Build tests." OFF)
 
 include(cmake/set_default_flags.cmake)
 include(cmake/set_default_build_to_release.cmake)
@@ -15,30 +13,23 @@ include(cmake/enable_code_style_check.cmake)
 
 find_package(ChimeraTK-DeviceAccess 03.14 REQUIRED)
 
-include(FindPkgConfig)
+find_package(ChimeraTK-EPICS REQUIRED)
 
-if(DEFINED EPICS_DIR)
-  set(ENV{PKG_CONFIG_PATH} $ENV{PKG_CONFIG_PATH}:${EPICS_DIR}/base/lib/pkgconfig)
-endif()
-
-message("Using PKG_CONFIG_PATH=$ENV{PKG_CONFIG_PATH}")
-pkg_check_modules(EPICS REQUIRED epics-base-linux-x86_64)
-#pkg_get_variable(EPICS_LIBS epics-base-linux-x86_64 EPICS_BASE_IOC_LIBS)
-pkg_get_variable(EPICS_LIBS epics-base-linux-x86_64 EPICS_BASE_HOST_LIBS)
-pkg_get_variable(EPICS_ARCH epics-base-linux-x86_64 ARCH)
-pkg_get_variable(EPICS_PATH epics-base-linux-x86_64 FINAL_LOCATION)
+get_target_property(EPICS_BASE ChimeraTK::EPICS INTERFACE_EPICS_BASE)
+get_target_property(EPICS_ARCH ChimeraTK::EPICS INTERFACE_EPICS_ARCH)
 
 list(APPEND CMAKE_INSTALL_RPATH ${EPICS_LIBRARY_DIRS})
 include_directories(include ${EPICS_INCLUDE_DIRS})
 
 aux_source_directory(${CMAKE_SOURCE_DIR}/src library_sources)
 
-add_library(${PROJECT_NAME} SHARED ${library_sources} )
+add_library(${PROJECT_NAME} SHARED ${library_sources})
 set_target_properties(${PROJECT_NAME} PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_FULL_LIBRARY_VERSION} SOVERSION ${${PROJECT_NAME}_SOVERSION})
-target_link_libraries(${PROJECT_NAME} PUBLIC ChimeraTK::ChimeraTK-DeviceAccess
-                                      PRIVATE ${EPICS_LIBS}
-                                      PRIVATE ${EPICS_LDFLAGS})
+target_link_libraries(${PROJECT_NAME} PUBLIC ChimeraTK::ChimeraTK-DeviceAccess PRIVATE ChimeraTK::EPICS)
+
+option(BUILD_TESTS "Build tests." ON)
+
 if(BUILD_TESTS)
   add_subdirectory(test)
 endif(BUILD_TESTS)
@@ -56,6 +47,7 @@ install(TARGETS ${PROJECT_NAME}
 
 # we support our cmake EXPORTS as imported targets
 set(PROVIDES_EXPORTED_TARGETS 1)
+
 # we need the public dependencies so create_cmake_config_files can find them as implicit dependencies
 list(APPEND ${PROJECT_NAME}_PUBLIC_DEPENDENCIES "ChimeraTK-DeviceAccess")
 include(${CMAKE_SOURCE_DIR}/cmake/create_cmake_config_files.cmake)

--- a/include/EPICS-Backend.h
+++ b/include/EPICS-Backend.h
@@ -87,6 +87,8 @@ namespace ChimeraTK {
      */
     bool _freshCreated;
 
+    ChimeraTK::VersionNumber _startVersion{nullptr};
+
     void fillCatalogueFromMapFile(const std::string& mapfile);
 
     void addCatalogueEntry(RegisterPath path, std::shared_ptr<std::string> pvName);

--- a/include/EPICSBackendRegisterAccessor.h
+++ b/include/EPICSBackendRegisterAccessor.h
@@ -302,6 +302,9 @@ namespace ChimeraTK {
 
     EpicsType* tp = (EpicsType*)pv->value;
     _currentVersion = EPICS::VersionMapper::getInstance().getVersion(tp[0].stamp);
+    if(_currentVersion < _backend->_startVersion) {
+      _currentVersion = _backend->_startVersion;
+    }
     TransferElement::_versionNumber = _currentVersion;
   }
 

--- a/src/EPICS-Backend.cc
+++ b/src/EPICS-Backend.cc
@@ -100,6 +100,7 @@ namespace ChimeraTK {
         std::lock_guard<std::mutex> lock(ChannelManager::getInstance().mapLock);
         ChannelManager::getInstance().activateChannels();
       }
+      _startVersion = {};
       setOpenedAndClearException();
     }
   }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,41 +1,43 @@
+find_program(PERL perl REQUIRED)
+
+FIND_PACKAGE(Boost 1.83 COMPONENTS unit_test_framework REQUIRED)
+
 add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/IOC
-                   COMMAND mkdir ${CMAKE_CURRENT_BINARY_DIR}/IOC)
-                   
-add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/IOC/ctkTestApp/Db/
-                   COMMAND ${EPICS_PATH}/bin/${EPICS_ARCH}/makeBaseApp.pl -t ioc -u ctkTest ctkTest
-                   COMMAND ${EPICS_PATH}/bin/${EPICS_ARCH}/makeBaseApp.pl -i -t ioc ctkTest
-                   DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IOC
-                   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/IOC)
-                   
+  COMMAND mkdir ${CMAKE_CURRENT_BINARY_DIR}/IOC)
+
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/IOC/ctkTestApp
+  COMMAND ${EPICS_BASE}/bin/${EPICS_ARCH}/makeBaseApp.pl -t ioc -u ctkTest ctkTest
+  COMMAND ${EPICS_BASE}/bin/${EPICS_ARCH}/makeBaseApp.pl -i -t ioc ctkTest
+  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IOC
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/IOC)
+
 add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/IOC/ctkTestApp/Db/ctkTest.db
-                   COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/test.db ${CMAKE_CURRENT_BINARY_DIR}/IOC/ctkTestApp/Db/ctkTest.db
-                   COMMAND sed -i -e 's/\#DB/DB/g' ${CMAKE_CURRENT_BINARY_DIR}/IOC/ctkTestApp/Db/Makefile
-                   COMMAND sed -i -e 's/xxx.db/ctkTest.db/g' ${CMAKE_CURRENT_BINARY_DIR}/IOC/ctkTestApp/Db/Makefile
-                   DEPENDS  ${CMAKE_CURRENT_BINARY_DIR}/IOC/ctkTestApp/Db/
-                   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/IOC)
+  COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/test.db ${CMAKE_CURRENT_BINARY_DIR}/IOC/ctkTestApp/Db/ctkTest.db
+  COMMAND sed -i -e 's/\#DB/DB/g' ${CMAKE_CURRENT_BINARY_DIR}/IOC/ctkTestApp/Db/Makefile
+  COMMAND sed -i -e 's/xxx.db/ctkTest.db/g' ${CMAKE_CURRENT_BINARY_DIR}/IOC/ctkTestApp/Db/Makefile
+  COMMAND sed -i -e 's/\#dbLoadRecords/dbLoadRecords/g' ${CMAKE_CURRENT_BINARY_DIR}/IOC/iocBoot/iocctkTest/st.cmd
+  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IOC/ctkTestApp
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/IOC)
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/IOC/bin
-                   COMMAND make
-                   DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IOC/ctkTestApp/Db/ctkTest.db
-                   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/IOC)                   
-                   
+  COMMAND make USR_LDFLAGS=-Wl,--rpath=${EPICS_BASE}/lib/${EPICS_ARCH}
+  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IOC/ctkTestApp/Db/ctkTest.db
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/IOC)
+
 # binary used during the developement of the backend - they require the EPICS example IOC to be running
 add_executable(testRead read.C)
-target_link_libraries(testRead ${EPICS_LIBS} ${EPICS_LDFLAGS})
+target_link_libraries(testRead ChimeraTK::EPICS)
 
 # binary used during the developement of the backend - they require the EPICS example IOC to be running
 add_executable(testReadAsync readAsync.C ${CMAKE_CURRENT_BINARY_DIR}/IOC/bin)
-target_link_libraries(testReadAsync ${EPICS_LIBS} ${EPICS_LDFLAGS})
+target_link_libraries(testReadAsync ChimeraTK::EPICS)
 
 # binary used during the developement of the backend
 add_executable(testPauseIOC testPauseIOC.C ${library_sources})
 set_target_properties(testPauseIOC PROPERTIES INCLUDE_DIRECTORIES ${CMAKE_CURRENT_BINARY_DIR})
 set_target_properties(testPauseIOC PROPERTIES COMPILE_FLAGS "-DCHIMERATK_UNITTEST")
 set_target_properties(testPauseIOC PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE)
-target_link_libraries(testPauseIOC PUBLIC ChimeraTK::ChimeraTK-DeviceAccess
-                                             PRIVATE ${EPICS_LIBS} 
-                                             PRIVATE ${EPICS_LDFLAGS})
-  
+target_link_libraries(testPauseIOC PUBLIC ChimeraTK::ChimeraTK-DeviceAccess PRIVATE ChimeraTK::EPICS)
 
 configure_file(testIOC.C.in testIOC.C)
 configure_file(DummyIOC/DummyIOC.h.in DummyIOC.h)
@@ -44,12 +46,9 @@ add_executable(testIOC ${CMAKE_CURRENT_BINARY_DIR}/testIOC.C)
 target_link_libraries(testIOC pthread)
 
 FILE(COPY test.map DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-message(STATUS "Library sources: ${EPICS_LIBS} ${EPICS_LDFLAGS}")
 add_executable(testUnifiedBackendTest testUnifiedBackendTest.C ${library_sources})
-include_directories(${CMAKE_CURRENT_BINARY_DIR} ${EPICS_INCLUDE_DIRS} ${PROJECT_SOURCE_DIR}/include)
-target_link_libraries(testUnifiedBackendTest PUBLIC ChimeraTK::ChimeraTK-DeviceAccess
-                                             PRIVATE ${EPICS_LIBS} 
-                                             PRIVATE ${EPICS_LDFLAGS})
+include_directories(${CMAKE_CURRENT_BINARY_DIR} ${PROJECT_SOURCE_DIR}/include)
+target_link_libraries(testUnifiedBackendTest PUBLIC ChimeraTK::ChimeraTK-DeviceAccess PRIVATE ChimeraTK::EPICS)
 set_target_properties(testUnifiedBackendTest PROPERTIES LINK_FLAGS "-Wl,--no-as-needed")
 set_target_properties(testUnifiedBackendTest PROPERTIES COMPILE_FLAGS "-DCHIMERATK_UNITTEST")
 set_target_properties(testUnifiedBackendTest PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE)

--- a/test/DummyIOC/DummyIOC.h.in
+++ b/test/DummyIOC/DummyIOC.h.in
@@ -66,7 +66,7 @@ struct IOCHelper {
   std::string getValue(const std::string& pvName) {
     std::array<char, 128> buffer;
     std::string result;
-    std::string cmd("@EPICS_PATH@/bin/@EPICS_ARCH@/caget -t ");
+    std::string cmd("@EPICS_BASE@/bin/@EPICS_ARCH@/caget -t ");
     cmd += pvName;
     std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.c_str(), "r"), pclose);
     if(!pipe) {

--- a/test/testIOC.C.in
+++ b/test/testIOC.C.in
@@ -18,11 +18,11 @@ int main() {
   bp::child c("@CMAKE_CURRENT_BINARY_DIR@/IOC/bin/@EPICS_ARCH@/ctkTest", "st.cmd",
       bp::start_dir("@CMAKE_CURRENT_BINARY_DIR@/IOC/iocBoot/iocctkTest"));
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  std::system("@EPICS_PATH@/bin/@EPICS_ARCH@/caget ctkTest:ao");
-  std::system("@EPICS_PATH@/bin/@EPICS_ARCH@/caput ctkTest:ao 42");
-  int status_before = std::system("@EPICS_PATH@/bin/@EPICS_ARCH@/caget ctkTest:ao");
+  std::system("@EPICS_BASE@/bin/@EPICS_ARCH@/caget ctkTest:ao");
+  std::system("@EPICS_BASE@/bin/@EPICS_ARCH@/caput ctkTest:ao 42");
+  int status_before = std::system("@EPICS_BASE@/bin/@EPICS_ARCH@/caget ctkTest:ao");
   c.terminate();
-  int status_after = std::system("@EPICS_PATH@/bin/@EPICS_ARCH@/caget ctkTest:ao");
+  int status_after = std::system("@EPICS_BASE@/bin/@EPICS_ARCH@/caget ctkTest:ao");
   std::cout << "Status code success: " << status_before << "\t Status code failure: " << status_after << std::endl;
   return 0;
 }


### PR DESCRIPTION
This unifies the EPICS version used with the ControlSystemAdapter-EPICS-IOC-Adapter, so they can be used together without potential collisions of symbols within the same binary.

The EPICS interface can be found here: https://github.com/ChimeraTK/epics-interface